### PR TITLE
Simplify generated code

### DIFF
--- a/compiler/src/main/kotlin/dev/jomu/krpc/compiler/Util.kt
+++ b/compiler/src/main/kotlin/dev/jomu/krpc/compiler/Util.kt
@@ -2,6 +2,7 @@ package dev.jomu.krpc.compiler
 
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeReference
 import kotlin.reflect.KClass
 
@@ -20,5 +21,18 @@ fun KSTypeReference.isClass(kClass: KClass<*>): Boolean {
         return false
     }
 
-   return declaration.qualifiedName?.asString() == kClass.qualifiedName
+    return declaration.qualifiedName?.asString() == kClass.qualifiedName
+}
+
+fun KSType.isAssignableFrom(kClass: KClass<*>): Boolean {
+    val declaration = declaration
+    if (declaration !is KSClassDeclaration) {
+        return false
+    }
+
+    if (declaration.qualifiedName?.asString() == kClass.qualifiedName) {
+        return true
+    }
+
+    return declaration.superTypes.any { it.isClass(kClass) }
 }

--- a/runtime/src/commonMain/kotlin/dev.jomu.krpc.runtime/Client.kt
+++ b/runtime/src/commonMain/kotlin/dev.jomu.krpc.runtime/Client.kt
@@ -1,5 +1,9 @@
 package dev.jomu.krpc.runtime
 
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.json.Json
+
 
 interface KrpcClient {
     suspend fun executeUnaryCall(url: String, message: EncodableMessage<*>): Call
@@ -8,7 +12,44 @@ interface KrpcClient {
 interface UnaryClientInterceptor {
     suspend fun <Req, Resp, Err> intercept(
         info: MethodInfo,
-        request: KrpcRequest<Req>,
-        next: suspend (KrpcRequest<Req>) -> Response<Resp, Err>
+        request: Req,
+        metadata: Metadata,
+        next: suspend (Req, Metadata) -> Response<Resp, Err>
     ): Response<Resp, Err>
+}
+
+open class BaseKrpcClient(
+    private val client: KrpcClient,
+    private val baseUrl: String,
+    private val interceptor: UnaryClientInterceptor?
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+    protected suspend fun <Req, Resp, Err> executeUnaryCall(
+        path: String,
+        info: MethodInfo,
+        request: Req,
+        requestMetadata: Metadata,
+        requestSerializer: SerializationStrategy<Req>,
+        responseDeserializer: DeserializationStrategy<Response<Resp, Err>>
+    ): Response<Resp, Err> {
+        val url = "${baseUrl}/$path"
+
+        val execute: suspend (Req, Metadata) -> Response<Resp, Err> = { request, metadata ->
+            val message = EncodableMessage(
+                metadata.toHttpHeaders(), request,
+                requestSerializer, json
+            )
+            val result = client.executeUnaryCall(url, message)
+
+            val metadata = Metadata.fromHttpHeaders(result.headers)
+
+            result.readRequest(json, responseDeserializer).withMetadata(metadata)
+        }
+
+        return try {
+            interceptor?.intercept(info, request, requestMetadata, execute) ?: execute(request, requestMetadata)
+        } catch (e: Throwable) {
+            Error(ErrorCode.INTERNAL, e.message ?: "<internal error>")
+        }
+    }
 }

--- a/runtime/src/commonMain/kotlin/dev.jomu.krpc.runtime/Response.kt
+++ b/runtime/src/commonMain/kotlin/dev.jomu.krpc.runtime/Response.kt
@@ -1,6 +1,13 @@
 package dev.jomu.krpc.runtime
 
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
 
 sealed class Response<T, E> {
     abstract val metadata: Metadata
@@ -53,5 +60,44 @@ class ResponseError<T>(
     val message: String,
     val details: T? = null
 )
+
+class ResponseSerializer<T, E>(private val successSerializer: KSerializer<T>, private val errorSerializer: KSerializer<E>) : KSerializer<Response<T, E>> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Response") {
+        element("success", successSerializer.descriptor, isOptional = true)
+        element("error", ResponseError.serializer(errorSerializer).descriptor, isOptional = true)
+    }
+
+    override fun deserialize(decoder: Decoder): Response<T, E> {
+        require(decoder is JsonDecoder) // this class can be decoded only by Json
+
+        val element = decoder.decodeJsonElement()
+
+        require(element is JsonObject)
+
+        if ("success" in element) {
+            return Success(decoder.json.decodeFromJsonElement(successSerializer, element["success"]!!))
+        }
+
+        if ("error" in element) {
+            val error = decoder.json.decodeFromJsonElement(ResponseError.serializer(errorSerializer), element["error"]!!)
+            return Error(error.code, error.message, error.details)
+        }
+
+        return Error(ErrorCode.INTERNAL, "Invalid response message: $element")
+    }
+
+    override fun serialize(encoder: Encoder, value: Response<T, E>) {
+        require(encoder is kotlinx.serialization.json.JsonEncoder) // This class can be encoded only by Json
+        val element = when (value) {
+            is Success -> buildJsonObject {
+                put("success", encoder.json.encodeToJsonElement(successSerializer, value.result))
+            }
+            is Error -> buildJsonObject {
+                put("error", encoder.json.encodeToJsonElement(ResponseError.serializer(errorSerializer), ResponseError(value.code, value.message, value.details)))
+            }
+        }
+        encoder.encodeJsonElement(element)
+    }
+}
 
 

--- a/sample/src/main/kotlin/dev/jomu/krpc/sample/Client.kt
+++ b/sample/src/main/kotlin/dev/jomu/krpc/sample/Client.kt
@@ -1,14 +1,12 @@
 package dev.jomu.krpc.sample
 
 import dev.jomu.krpc.runtime.KtorClient
-import dev.jomu.krpc.runtime.Metadata
 import io.ktor.client.*
 import io.ktor.client.engine.okhttp.*
 
 suspend fun main() {
     val client = TestServiceClient(KtorClient(HttpClient(OkHttp)), "http://127.0.0.1:8080", PrintInterceptor)
 
-    val r = client.hello("Johannes", Metadata(mapOf("a" to "b")))
+    val r = client.third("Johannes", 123, 42.42f)
     println(r)
-
 }

--- a/sample/src/main/kotlin/dev/jomu/krpc/sample/Interface.kt
+++ b/sample/src/main/kotlin/dev/jomu/krpc/sample/Interface.kt
@@ -16,5 +16,5 @@ interface GenericBase<T> {
 interface TestService : GenericBase<String> {
     suspend fun hello(name: String, metadata: Metadata): Response<String, Unit>
     suspend fun second(name: String, number: Int): Response<String, CustomError>
-    suspend fun third(name: String, number: Int, more: Float): Response<List<String>, CustomError>
+    suspend fun third(name: String, number: Int, more: Float): Response<List<List<String>>, CustomError>
 }

--- a/sample/src/main/kotlin/dev/jomu/krpc/sample/Server.kt
+++ b/sample/src/main/kotlin/dev/jomu/krpc/sample/Server.kt
@@ -27,8 +27,8 @@ object Implementation : TestService {
         return Error(ErrorCode.INTERNAL, "we got an error chief", CustomError(123))
     }
 
-    override suspend fun third(name: String, number: Int, more: Float): Response<List<String>, CustomError> {
-        return Success(listOf(name, "$number"))
+    override suspend fun third(name: String, number: Int, more: Float): Response<List<List<String>>, CustomError> {
+        return Success(listOf(listOf(name, "$number")))
     }
 
     @OptIn(ExperimentalStdlibApi::class)
@@ -44,11 +44,12 @@ object Implementation : TestService {
 object PrintInterceptor : UnaryServerInterceptor, UnaryClientInterceptor {
     override suspend fun <Req, Resp, Err> intercept(
         info: MethodInfo,
-        request: KrpcRequest<Req>,
-        next: suspend (KrpcRequest<Req>) -> Response<Resp, Err>
+        request: Req,
+        metadata: Metadata,
+        next: suspend (Req, Metadata) -> Response<Resp, Err>
     ): Response<Resp, Err> {
-        println("Request: $request")
-        val response = next(request).also {
+        println("Request: $request with $metadata")
+        val response = next(request, metadata).also {
             println("Response: $it")
         }
         return response.withMetadata(Metadata(response.metadata.values.mapValues { (_, value) -> value.uppercase(Locale.getDefault()) }))


### PR DESCRIPTION
* move more functionality into runtime
* directly serialize `Response` objects and get rid of wrappers